### PR TITLE
Fix to crash when min/max heights changed from default.

### DIFF
--- a/music_default/surface_night.lua
+++ b/music_default/surface_night.lua
@@ -3,8 +3,8 @@ if minetest.get_modpath("music_dfcaverns") then
     min_default = -8
 end
 
-local ymax = minetest.settings:get("music_default_surface_ymax") or 31000
-local ymin = minetest.settings:get("music_default_surface_ymin") or min_default
+local ymax = tonumber(minetest.settings:get("music_default_surface_ymax")) or 31000
+local ymin = tonumber(minetest.settings:get("music_default_surface_ymin"))or min_default
 
 music.register_track({
     name = "anguish",

--- a/music_default/surface_night.lua
+++ b/music_default/surface_night.lua
@@ -4,7 +4,7 @@ if minetest.get_modpath("music_dfcaverns") then
 end
 
 local ymax = tonumber(minetest.settings:get("music_default_surface_ymax")) or 31000
-local ymin = tonumber(minetest.settings:get("music_default_surface_ymin"))or min_default
+local ymin = tonumber(minetest.settings:get("music_default_surface_ymin")) or min_default
 
 music.register_track({
     name = "anguish",


### PR DESCRIPTION
Uses "tonumber" function to convert user configured min/max heights to integers to address crashes described in issue #1.